### PR TITLE
[feature]: support of Go for VScode extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keployio",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "keployio",
-      "version": "1.0.2",
+      "version": "1.0.6",
       "dependencies": {
         "acorn-walk": "^8.3.3",
         "axios": "^1.7.4",

--- a/scripts/bash/keploy_record_script.sh
+++ b/scripts/bash/keploy_record_script.sh
@@ -27,8 +27,23 @@ touch "$log_file_path"
 chmod 666 "$log_file_path"
 
 if [[ "$command" =~ .*"go".* ]]; then
-  go mod download
-  go build -o application
+  # Check for go.mod file
+  if [[ -f "go.mod" ]]; then
+    go mod download
+  else
+    echo "No go.mod file found. Skipping dependency download."
+  fi
+
+  # Check if the command is 'go run'
+  if [[ "$command" =~ "go run" ]]; then
+    echo "Using 'go run' command as specified."
+  else
+    # Build the application
+    go build -o application
+  fi
+
+  # You could add more Go-specific setup here if needed
+fi
 
 elif [[ "$command" =~ .*"python3".* ]]; then
   # echo "Python3 command found"

--- a/scripts/utg.sh
+++ b/scripts/utg.sh
@@ -2,21 +2,45 @@
 
 export API_KEY="1234"
 
-
 sourceFilePath=$1
 testFilePath=$2
 
+# Function to run Go tests
+run_go_tests() {
+    local sourcePath=$1
+    local testPath=$2
+    
+    # Ensure the test file exists
+    if [ ! -f "$testPath" ]; then
+        echo "// Test file for $(basename $sourcePath)" > "$testPath"
+    fi
 
-# Add env variables to the npm test command
-# utgEnv=" -- --coverage --coverageReporters=text --coverageReporters=cobertura --coverageDirectory=./coverage"
+    # Run Go tests with coverage
+    go test -v -coverprofile=coverage.out "$sourcePath"
+    
+    # Convert coverage to HTML (optional, but useful for visualization)
+    go tool cover -html=coverage.out -o ./coverage/coverage.html
 
-# testCommand="npm test "+ $utgEnv
+    # Convert coverage to Cobertura XML format for compatibility
+    go-cover-treemap -coverprofile coverage.out -o ./coverage/cobertura-coverage.xml
+}
 
+# Check if the source file is a Go file
+if [[ "$sourceFilePath" == *.go ]]; then
+    # For Go files
+    testFilePath="${sourceFilePath%.*}_test.go"
+    run_go_tests "$sourceFilePath" "$testFilePath"
+else
+    # For JavaScript/TypeScript files
+    # Add env variables to the npm test command
+    utgEnv=" -- --coverage --coverageReporters=text --coverageReporters=cobertura --coverageDirectory=./coverage"
 
-keploy gen --source-file-path="$sourceFilePath" \
-  --test-file-path="$testFilePath" \
-  --test-command="npm test -- --coverage --coverageReporters=text --coverageReporters=cobertura --coverageDirectory=./coverage
-" \
-  --coverage-report-path="./coverage/cobertura-coverage.xml"\
- --llmApiVersion "2024-02-01" --llmBaseUrl "https://api.keploy.io" --max-iterations "10"
+    testCommand="npm test $utgEnv"
+
+    keploy gen --source-file-path="$sourceFilePath" \
+      --test-file-path="$testFilePath" \
+      --test-command="$testCommand" \
+      --coverage-report-path="./coverage/cobertura-coverage.xml"\
+      --llmApiVersion "2024-02-01" --llmBaseUrl "https://api.keploy.io" --max-iterations "10"
+fi
 

--- a/src/OneClickInstall.ts
+++ b/src/OneClickInstall.ts
@@ -1,60 +1,62 @@
-import { exec } from 'child_process';
-import * as os from 'os';
-import * as vscode from 'vscode';
+import { exec } from "child_process";
+import * as os from "os";
+import * as vscode from "vscode";
 
 export default function executeKeployOneClickCommand(): void {
-    const platform = os.platform();
-    let command: string;
+	const platform = os.platform();
+	let command: string;
 
-    if (platform === 'win32') {
-        command = `powershell -Command "iwr https://raw.githubusercontent.com/keploy/keploy/main/windows-install.ps1 -useb | iex"`;
-    } else if (platform === 'darwin' || platform === 'linux') {
-        command = `curl --silent -L https://raw.githubusercontent.com/keploy/keploy/main/install.sh | bash`;
-    } else {
-        vscode.window.showErrorMessage(`Unsupported platform: ${platform}`);
-        return;
-    }
+	if (platform === "win32") {
+		// for future use
+		command = `powershell -Command "iwr https://raw.githubusercontent.com/keploy/keploy/main/windows-install.ps1 -useb | iex"`;
+	} else if (platform === "darwin" || platform === "linux") {
+		command = `curl --silent -O -L https://keploy.io/install.sh && source install.sh`;
+	} else {
+		vscode.window.showErrorMessage(`Unsupported platform: ${platform}`);
+		return;
+	}
 
-    const terminal = vscode.window.createTerminal('Keploy Installation');
-    terminal.show();
-    terminal.sendText(command);
+	const terminal = vscode.window.createTerminal("Keploy Installation");
+	terminal.show();
+	terminal.sendText(command);
 
-    terminal.sendText('keploy --version');
+	terminal.sendText("keploy --version");
 
-    // Check if Go is installed
-    checkGoInstallation(terminal);
+	// Check if Go is installed
+	// checkGoInstallation(terminal);
 }
 
-function checkGoInstallation(terminal: vscode.Terminal): void {
-    exec('go version', (error, stdout, stderr) => {
-        if (error) {
-            vscode.window.showWarningMessage('Go is not installed. Installing Go is recommended for using Keploy with Go projects.');
-            const installGoCommand = getGoInstallCommand();
-            if (installGoCommand) {
-                vscode.window.showInformationMessage('Would you like to install Go?', 'Yes', 'No')
-                    .then(selection => {
-                        if (selection === 'Yes') {
-                            terminal.sendText(installGoCommand);
-                        }
-                    });
-            }
-        } else {
-            vscode.window.showInformationMessage(`Go is installed: ${stdout.trim()}`);
-        }
-    });
-}
+// // not needed if someone working with go project will have go installed already on their system
+// function checkGoInstallation(terminal: vscode.Terminal): void {
+//     exec('go version', (error, stdout, stderr) => {
+//         if (error) {
+//             vscode.window.showWarningMessage('Go is not installed. Installing Go is recommended for using Keploy with Go projects.');
+//             const installGoCommand = getGoInstallCommand();
+//             if (installGoCommand) {
+//                 vscode.window.showInformationMessage('Would you like to install Go?', 'Yes', 'No')
+//                     .then(selection => {
+//                         if (selection === 'Yes') {
+//                             terminal.sendText(installGoCommand);
+//                         }
+//                     });
+//             }
+//         } else {
+//             vscode.window.showInformationMessage(`Go is installed: ${stdout.trim()}`);
+//         }
+//     });
+// }
 
-function getGoInstallCommand(): string | null {
-    const platform = os.platform();
-    switch (platform) {
-        case 'darwin':
-            return 'brew install go';
-        case 'linux':
-            return 'sudo apt-get update && sudo apt-get install golang-go';
-        case 'win32':
-            return 'choco install golang';
-        default:
-            vscode.window.showErrorMessage(`Unsupported platform for Go installation: ${platform}`);
-            return null;
-    }
-}
+// function getGoInstallCommand(): string | null {
+//     const platform = os.platform();
+//     switch (platform) {
+//         case 'darwin':
+//             return 'brew install go';
+//         case 'linux':
+//             return 'sudo apt-get update && sudo apt-get install golang-go';
+//         case 'win32':
+//             return 'choco install golang';
+//         default:
+//             vscode.window.showErrorMessage(`Unsupported platform for Go installation: ${platform}`);
+//             return null;
+//     }
+// }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import { readFileSync  , appendFile} from 'fs';
+import { readFileSync, appendFile } from 'fs';
 import * as child_process from 'child_process';
 import * as os from 'os';
+import * as path from 'path';
 
 function extractTestSetName(logContent: string) {
     // Define the regular expression pattern to find the test set name
@@ -12,9 +13,10 @@ function extractTestSetName(logContent: string) {
   
     // Check if a match was found and return the test set name, otherwise return null
     return match ? match[1] : null;
-  }
+}
+
 export async function displayRecordedTestCases(logfilePath: string, webview: any): Promise<void> {
-    console.log('Displaying Recorded test  cases');
+    console.log('Displaying Recorded test cases');
     let logData;
     try {
         try {
@@ -28,32 +30,33 @@ export async function displayRecordedTestCases(logfilePath: string, webview: any
         }
 
         const testSetName = extractTestSetName(logData);
-    // Split the log data into lines
-    const logLines = logData.split('\n');
-    // Filter out the lines containing the desired information
-    const capturedTestLines = logLines.filter(line => line.includes('🟠 Keploy has captured test cases'));
-    // Display the captured test cases in your frontend
-    if (capturedTestLines.length === 0) {
-        webview.postMessage({
-            type: 'testcaserecorded',
-            value: 'Test Case has been recorded',
-            textContent: "No test cases captured. Please try again.",
-            noTestCases: true
+        // Split the log data into lines
+        const logLines = logData.split('\n');
+        // Filter out the lines containing the desired information
+        const capturedTestLines = logLines.filter(line => line.includes('🟠 Keploy has captured test cases'));
+        // Display the captured test cases in your frontend
+        if (capturedTestLines.length === 0) {
+            webview.postMessage({
+                type: 'testcaserecorded',
+                value: 'Test Case has been recorded',
+                textContent: "No test cases captured. Please try again.",
+                noTestCases: true
+            });
+            return;
+        }
+        capturedTestLines.forEach(testLine => {
+            const testCaseInfo = JSON.parse(testLine.substring(testLine.indexOf('{')));
+            const textContent = `"${testCaseInfo['testcase name']}"`;
+            const path = testCaseInfo.path + '/' + testCaseInfo['testcase name'] + '.yaml';
+            webview.postMessage({
+                type: 'testcaserecorded',
+                value: 'Test Case has been recorded',
+                textContent: textContent,
+                path: path,
+                testSetName: testSetName
+            });
         });
-        return;
     }
-    capturedTestLines.forEach(testLine => {
-        const testCaseInfo = JSON.parse(testLine.substring(testLine.indexOf('{')));
-        const textContent = `"${testCaseInfo['testcase name']}"`;
-        const path = testCaseInfo.path + '/' + testCaseInfo['testcase name'] + '.yaml';
-        webview.postMessage({
-            type: 'testcaserecorded',
-            value: 'Test Case has been recorded',
-            textContent: textContent,
-            path: path,
-            testSetName: testSetName
-        });
-    });}
     catch(error){
         console.log(error);
         webview.postMessage({
@@ -83,29 +86,22 @@ export async function stopRecording(){
     }
 }
 
-
-export async function startRecording( wslscriptPath: string, wsllogfilePath: string, bashScriptPath: string, zshScriptPath : string ,  logfilePath: string, webview: any): Promise<void> {
+export async function startRecording(wslscriptPath: string, wsllogfilePath: string, bashScriptPath: string, zshScriptPath: string, logfilePath: string, webview: any): Promise<void> {
     try {
         return new Promise<void>((resolve, reject) => {
             try {
                 let terminalPath: string;
-                let currentShell ='';
+                let currentShell = '';
 
                 if (process.platform === 'win32') {
                     terminalPath = 'wsl.exe';
                 } else {
                     terminalPath = '/bin/bash';
-                    // Get the default shell for the current user
                     currentShell = process.env.SHELL || '';
-
                     if (!currentShell) {
-                        // Fallback method if process.env.SHELL is not set
                         currentShell = child_process.execSync('echo $SHELL', { encoding: 'utf8' }).trim();
                     }
-
                     console.log(`Current default shell: ${currentShell}`);
-                    //uncomment the below line if you want to use the default shell (for zsh test)
-                    // terminalPath = currentShell; 
                 }
                 console.log(`Terminal path: ${terminalPath}`);
                 const terminal = vscode.window.createTerminal({
@@ -113,22 +109,37 @@ export async function startRecording( wslscriptPath: string, wsllogfilePath: str
                     shellPath: terminalPath,
                 });
                 terminal.show();
-                if (process.platform === 'win32') {
-                    const recordCmd = `${wslscriptPath} "${wsllogfilePath}" ;exit 0`;
-                    terminal.sendText(recordCmd);
-                } else {
-                    let recordCmd: string;
-                    if (currentShell.includes('zsh')) {
-                        // Use a Zsh-specific script if needed
-                        //replace bashScriptPath with zshScriptPath for zsh
-                        recordCmd = `"${bashScriptPath}" "${logfilePath}" `;
-                    } else {
-                        // Default to Bash script
-                        recordCmd = `"${bashScriptPath}" "${logfilePath}" ;exit 0`;
-                    }
-                    console.log(recordCmd);
-                    terminal.sendText(recordCmd);
+
+                const editor = vscode.window.activeTextEditor;
+                if (!editor) {
+                    vscode.window.showErrorMessage('No active editor found');
+                    reject(new Error('No active editor found'));
+                    return;
                 }
+
+                const document = editor.document;
+                const filePath = document.uri.fsPath;
+                let recordCmd: string;
+
+                if (filePath.endsWith('.go')) {
+                    // For Go files
+                    const packageName = path.basename(path.dirname(filePath));
+                    recordCmd = `keploy record -c "go run ${filePath}" --delay 5 > "${logfilePath}"`;
+                } else {
+                    // For JS/TS files
+                    if (process.platform === 'win32') {
+                        recordCmd = `${wslscriptPath} "${wsllogfilePath}" ;exit 0`;
+                    } else {
+                        if (currentShell.includes('zsh')) {
+                            recordCmd = `"${zshScriptPath}" "${logfilePath}" `;
+                        } else {
+                            recordCmd = `"${bashScriptPath}" "${logfilePath}" ;exit 0`;
+                        }
+                    }
+                }
+
+                console.log(recordCmd);
+                terminal.sendText(recordCmd);
 
                 // Listen for terminal close event
                 const disposable = vscode.window.onDidCloseTerminal(eventTerminal => {

--- a/src/Utg.ts
+++ b/src/Utg.ts
@@ -2,55 +2,70 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
-
 async function Utg(context: vscode.ExtensionContext) {
     try {
         return new Promise<void>((resolve, reject) => {
             try {
-                // Create a terminal named "Keploy Terminal"
                 const terminal = vscode.window.createTerminal("Keploy Terminal");
-
                 terminal.show();
-                // Your command logic here
+
                 const editor = vscode.window.activeTextEditor;
                 let currentFilePath = "";
                 if (editor) {
                     const document = editor.document;
                     currentFilePath = document.uri.fsPath;
                     vscode.window.showInformationMessage(`Current opened file: ${currentFilePath}`);
-                    // Add your additional logic here
                 } else {
                     vscode.window.showInformationMessage('No file is currently opened.');
+                    return;
                 }
-                const scriptPath = path.join(context.extensionPath, 'scripts', 'utg.sh');
 
+                const scriptPath = path.join(context.extensionPath, 'scripts', 'utg.sh');
 
                 const sourceFilePath = currentFilePath;
                 ensureTestFileExists(sourceFilePath);
-
 
                 if (!vscode.workspace.workspaceFolders) {
                     vscode.window.showErrorMessage('No workspace is opened.');
                     return;
                 }
-                const rootDir = vscode.workspace.workspaceFolders[0].uri.fsPath; // Root directory of the project
+                const rootDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
                 const testDir = path.join(rootDir, 'test');
-                const testFilePath = path.join(testDir, path.basename(sourceFilePath).replace('.js', '.test.js'));
+                
+                let testFilePath: string;
+                if (sourceFilePath.endsWith('.go')) {
+                    // For Go files
+                    const sourceFileName = path.basename(sourceFilePath);
+                    const testFileName = sourceFileName.replace('.go', '_test.go');
+                    testFilePath = path.join(path.dirname(sourceFilePath), testFileName);
+                } else {
+                    // For JavaScript/TypeScript files
+                    testFilePath = path.join(testDir, path.basename(sourceFilePath).replace(/\.(js|ts)$/, '.test.$1'));
+                }
+
                 if (!fs.existsSync(testFilePath)) {
-                    vscode.window.showInformationMessage("Test doesn't exists", testFilePath);
-                    fs.writeFileSync(testFilePath, `// Test file for ${testFilePath}`);
+                    vscode.window.showInformationMessage("Test doesn't exist", testFilePath);
+                    fs.writeFileSync(testFilePath, `// Test file for ${path.basename(sourceFilePath)}`);
                 }
 
                 vscode.window.showInformationMessage("testFilePath", testFilePath);
                 const coverageReportPath = "./coverage/cobertura-coverage.xml";
-                terminal.sendText(`sh "${scriptPath}" "${sourceFilePath}" "${testFilePath}" "${coverageReportPath}";`);
 
-                // Listen for terminal close event
+                // Adjust the command based on the file type
+                let command: string;
+                if (sourceFilePath.endsWith('.go')) {
+                    command = `go test -v -coverprofile=coverage.out ${sourceFilePath}; go tool cover -html=coverage.out -o ${coverageReportPath}`;
+                } else {
+                    command = `sh "${scriptPath}" "${sourceFilePath}" "${testFilePath}" "${coverageReportPath}";`;
+                }
+
+                terminal.sendText(command);
+
                 const disposable = vscode.window.onDidCloseTerminal(eventTerminal => {
                     console.log('Terminal closed');
                     if (eventTerminal === terminal) {
-                        disposable.dispose(); // Dispose the listener
-                        resolve(); // Resolve the promise
+                        disposable.dispose();
+                        resolve();
                     }
                 });
 
@@ -72,16 +87,21 @@ async function ensureTestFileExists(sourceFilePath: string): Promise<void> {
         vscode.window.showErrorMessage('No workspace is opened.');
         return;
     }
-    const rootDir = path.dirname(vscode.workspace.workspaceFolders[0].uri.fsPath); // Root directory of the project
+    const rootDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
-    const testDir = path.join(rootDir, 'test');
-    const relativeSourceFilePath = path.relative(rootDir, sourceFilePath);
-    const sourceFileName = path.basename(sourceFilePath);
-    const testFileName = sourceFileName.replace('.js', '.test.js');
-    const testFilePath = path.join(testDir, relativeSourceFilePath.replace(sourceFileName, testFileName));
-
-    if (!fs.existsSync(testDir)) {
-        fs.mkdirSync(testDir, { recursive: true });
+    let testFilePath: string;
+    if (sourceFilePath.endsWith('.go')) {
+        // For Go files, create the test file in the same directory
+        const sourceFileName = path.basename(sourceFilePath);
+        const testFileName = sourceFileName.replace('.go', '_test.go');
+        testFilePath = path.join(path.dirname(sourceFilePath), testFileName);
+    } else {
+        // For JavaScript/TypeScript files
+        const testDir = path.join(rootDir, 'test');
+        const relativeSourceFilePath = path.relative(rootDir, sourceFilePath);
+        const sourceFileName = path.basename(sourceFilePath);
+        const testFileName = sourceFileName.replace(/\.(js|ts)$/, '.test.$1');
+        testFilePath = path.join(testDir, relativeSourceFilePath.replace(sourceFileName, testFileName));
     }
 
     const testFileDir = path.dirname(testFilePath);
@@ -90,7 +110,7 @@ async function ensureTestFileExists(sourceFilePath: string): Promise<void> {
     }
 
     if (!fs.existsSync(testFilePath)) {
-        fs.writeFileSync(testFilePath, `// Test file for ${sourceFileName}`);
+        fs.writeFileSync(testFilePath, `// Test file for ${path.basename(sourceFilePath)}`);
         vscode.window.showInformationMessage(`Created test file: ${testFilePath}`);
     } else {
         vscode.window.showInformationMessage(`Test file already exists: ${testFilePath}`);

--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -11,7 +11,19 @@ export const execShell = (cmd: string) => {
             // Execute the command in the default shell if on other platforms
             commandToExecute = cmd;
         }
-        exec(commandToExecute, (err, stdout, stderr) => {
+
+        // Set up environment for Go commands
+        const env = { ...process.env };
+        if (cmd.startsWith('go ')) {
+            // Ensure GOPATH is set
+            if (!env.GOPATH) {
+                env.GOPATH = `${os.homedir()}/go`;
+            }
+            // Add Go binary directory to PATH
+            env.PATH = `${env.GOPATH}/bin:${env.PATH}`;
+        }
+
+        exec(commandToExecute, { env }, (err, stdout, stderr) => {
             if (err) {
                 reject(err.message);
                 return;
@@ -21,6 +33,5 @@ export const execShell = (cmd: string) => {
             }
             resolve(stdout);
         });
-        
     });
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,240 +1,263 @@
-import * as vscode from 'vscode';
-import { SidebarProvider } from './SidebarProvider';
-import SignIn, { validateFirst } from './SignIn';
-import oneClickInstall from './OneClickInstall';
-import { getKeployVersion, getCurrentKeployVersion } from './version';
-import { downloadAndUpdate, downloadAndUpdateDocker } from './updateKeploy';
-import Utg from './Utg';
-import { getGitHubAccessToken, getMicrosoftAccessToken, getInstallationID } from './SignIn';
-import * as acorn from 'acorn';
-import * as walk from 'acorn-walk';
+import * as vscode from "vscode";
+import { SidebarProvider } from "./SidebarProvider";
+import SignIn, { validateFirst } from "./SignIn";
+import oneClickInstall from "./OneClickInstall";
+import { getKeployVersion, getCurrentKeployVersion } from "./version";
+import { downloadAndUpdate, downloadAndUpdateDocker } from "./updateKeploy";
+import Utg from "./Utg";
+import {
+	getGitHubAccessToken,
+	getMicrosoftAccessToken,
+	getInstallationID,
+} from "./SignIn";
+import * as acorn from "acorn";
+import * as walk from "acorn-walk";
 
 class KeployCodeLensProvider implements vscode.CodeLensProvider {
-    onDidChangeCodeLenses?: vscode.Event<void> | undefined;
+	onDidChangeCodeLenses?: vscode.Event<void> | undefined;
 
-    provideCodeLenses(
-        document: vscode.TextDocument,
-        token: vscode.CancellationToken
-    ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-        const fileName = document.uri.fsPath;
-        if (fileName.endsWith('.test.js') || fileName.endsWith('.test.ts') || fileName.endsWith('_test.go')) {
-            return [];
-        }
+	provideCodeLenses(
+		document: vscode.TextDocument,
+		token: vscode.CancellationToken
+	): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+		const fileName = document.uri.fsPath;
+		if (
+			fileName.endsWith(".test.js") ||
+			fileName.endsWith(".test.ts") ||
+			fileName.endsWith("_test.go")
+		) {
+			// Added support for Go test files
+			return [];
+		}
 
-        const text = document.getText();
-        const codeLenses: vscode.CodeLens[] = [];
+		const text = document.getText();
+		const codeLenses: vscode.CodeLens[] = [];
 
-        try {
-            if (fileName.endsWith('.go')) {
-                this.parseGoFile(text, document, codeLenses);
-            } else {
-                this.parseJstsFile(text, document, codeLenses);
-            }
-        } catch (error) {
-            console.error(error);
-        }
+		try {
+			const ast = acorn.parse(text, {
+				ecmaVersion: 2020,
+				sourceType: "module",
+			});
 
-        return codeLenses;
-    }
+			walk.fullAncestor(ast, (node: any, state: any, ancestors: any[]) => {
+				if (
+					node.type === "FunctionDeclaration" ||
+					node.type === "FunctionExpression"
+				) {
+					const line = document.positionAt(node.start).line;
+					const range = new vscode.Range(line, 0, line, 0);
+					codeLenses.push(
+						new vscode.CodeLens(range, {
+							title: "🐰 Generate unit tests",
+							command: "keploy.utg",
+							arguments: [document.uri.fsPath],
+						})
+					);
+				} else if (node.type === "ArrowFunctionExpression") {
+					const parent = ancestors[ancestors.length - 2];
+					if (
+						parent.type !== "CallExpression" ||
+						(parent.callee.property?.name !== "then" &&
+							parent.callee.property?.name !== "catch")
+					) {
+						const line = document.positionAt(node.start).line;
+						const range = new vscode.Range(line, 0, line, 0);
+						codeLenses.push(
+							new vscode.CodeLens(range, {
+								title: "🐰 Generate unit tests",
+								command: "keploy.utg",
+								arguments: [document.uri.fsPath],
+							})
+						);
+					}
+				}
+			});
+		} catch (error) {
+			console.error(error);
+		}
 
-    private parseGoFile(text: string, document: vscode.TextDocument, codeLenses: vscode.CodeLens[]) {
-        const functionRegex = /func\s+(\w+)\s*\([^)]*\)\s*(\([^)]*\))?\s*{/g;
-        let match;
-        while ((match = functionRegex.exec(text)) !== null) {
-            const line = document.positionAt(match.index).line;
-            this.addCodeLens(document, line, codeLenses);
-        }
-    }
-
-    private parseJstsFile(text: string, document: vscode.TextDocument, codeLenses: vscode.CodeLens[]) {
-        const ast = acorn.parse(text, { ecmaVersion: 2020, sourceType: 'module' });
-        walk.simple(ast, {
-            FunctionDeclaration: (node: any) => {
-                const line = document.positionAt(node.start).line;
-                this.addCodeLens(document, line, codeLenses);
-            },
-            FunctionExpression: (node: any) => {
-                const line = document.positionAt(node.start).line;
-                this.addCodeLens(document, line, codeLenses);
-            },
-            ArrowFunctionExpression: (node: any) => {
-                const line = document.positionAt(node.start).line;
-                this.addCodeLens(document, line, codeLenses);
-            }
-        });
-    }
-
-    private addCodeLens(document: vscode.TextDocument, line: number, codeLenses: vscode.CodeLens[]) {
-        const range = new vscode.Range(line, 0, line, 0);
-        codeLenses.push(new vscode.CodeLens(range, {
-            title: '🐰 Generate unit tests',
-            command: 'keploy.utg',
-            arguments: [document.uri.fsPath]
-        }));
-    }
+		return codeLenses;
+	}
 }
-
 
 export function activate(context: vscode.ExtensionContext) {
-    const sidebarProvider = new SidebarProvider(context.extensionUri);
-    context.subscriptions.push(
-        vscode.window.registerWebviewViewProvider(
-            "Keploy-Sidebar",
-            sidebarProvider
-        ),
-        vscode.languages.registerCodeLensProvider(
-            [
-                { language: 'javascript', scheme: 'file' },
-                { language: 'typescript', scheme: 'file' },
-                { language: 'go', scheme: 'file' }
-            ],
-            new KeployCodeLensProvider()
-        )
-    );
+	const sidebarProvider = new SidebarProvider(context.extensionUri);
+	context.subscriptions.push(
+		vscode.window.registerWebviewViewProvider(
+			"Keploy-Sidebar",
+			sidebarProvider
+		),
+		vscode.languages.registerCodeLensProvider(
+			{ language: "javascript", scheme: "file" },
+			new KeployCodeLensProvider()
+		),
+		vscode.languages.registerCodeLensProvider(
+			{ language: "typescript", scheme: "file" },
+			new KeployCodeLensProvider()
+		),
+		vscode.languages.registerCodeLensProvider(
+			// Added registration for Go language
+			{ language: "go", scheme: "file" },
+			new KeployCodeLensProvider()
+		)
+	);
 
-    oneClickInstall();
+	oneClickInstall();
 
-    let signedIn = context.globalState.get('ourToken');
-    console.log(context.globalState);
-    if (signedIn) {
-        vscode.commands.executeCommand('setContext', 'keploy.signedIn', true);
-        sidebarProvider.postMessage('navigateToHome', 'KeployHome');
-    }
+	let signedIn = context.globalState.get("ourToken");
+	console.log(context.globalState);
+	if (signedIn) {
+		vscode.commands.executeCommand("setContext", "keploy.signedIn", true);
+		sidebarProvider.postMessage("navigateToHome", "KeployHome");
+	}
 
-    // Check if the access token is already present in the global state
-    const accessToken = context.globalState.get<string>('accessToken');
-    // disable if access token is already present
-    if (accessToken) {
-        // Disable the sign-in command since the user is already signed in
-        vscode.commands.executeCommand('setContext', 'keploy.signedIn', true);
-        vscode.window.showInformationMessage('You are already signed in!');
-        // enable the signout command
-        vscode.commands.executeCommand('setContext', 'keploy.signedOut', false);
+	const accessToken = context.globalState.get<string>("accessToken");
+	if (accessToken) {
+		vscode.commands.executeCommand("setContext", "keploy.signedIn", true);
+		vscode.window.showInformationMessage("You are already signed in!");
+		vscode.commands.executeCommand("setContext", "keploy.signedOut", false);
+	} else {
+		vscode.commands.executeCommand("setContext", "keploy.signedOut", true);
+		let signInCommand = vscode.commands.registerCommand(
+			"keploy.SignIn",
+			async () => {
+				try {
+					const result = await getGitHubAccessToken();
 
-    } else {
-        vscode.commands.executeCommand('setContext', 'keploy.signedOut', true);
-        // Register the sign-in command if not signed in
-        let signInCommand = vscode.commands.registerCommand('keploy.SignIn', async () => {
-            try {
-                const result = await getGitHubAccessToken();
+					if (result) {
+						const { accessToken, email } = result;
 
-                if (result) {
-                    const { accessToken, email } = result;
+						getInstallationID();
 
-                    getInstallationID();
+						await context.globalState.update("accessToken", accessToken);
 
-                    // Store the access token in global state
-                    await context.globalState.update('accessToken', accessToken);
+						const { emailID, isValid, error } = await validateFirst(
+							accessToken,
+							"https://api.keploy.io"
+						);
 
-                    const { emailID, isValid, error } = await validateFirst(accessToken, "https://api.keploy.io");
+						vscode.window.showInformationMessage("You are now signed in!");
+						vscode.commands.executeCommand(
+							"setContext",
+							"keploy.signedIn",
+							true
+						);
+						vscode.commands.executeCommand(
+							"setContext",
+							"keploy.signedOut",
+							false
+						);
+					} else {
+						console.log("Failed to get the session or email.");
+						vscode.window.showInformationMessage("Failed to sign in Keploy!");
+					}
+				} catch (error) {
+					vscode.window.showInformationMessage("Failed to sign in Keploy!");
+				}
+			}
+		);
 
-                    // if (isValid) {
-                    vscode.window.showInformationMessage('You are now signed in!');
-                    vscode.commands.executeCommand('setContext', 'keploy.signedIn', true);
-                    vscode.commands.executeCommand('setContext', 'keploy.signedOut', false);
-                    // } else {
-                    //     console.log('Validation failed for the user !');
-                    // }
+		context.subscriptions.push(signInCommand);
+	}
 
-                } else {
-                    console.log('Failed to get the session or email.');
-                    vscode.window.showInformationMessage('Failed to sign in Keploy!');
-                }
-            } catch (error) {
-                // console.error('Error during sign-in:', error);
-                vscode.window.showInformationMessage('Failed to sign in Keploy!');
-            }
-        });
+	let signout = vscode.commands.registerCommand("keploy.SignOut", async () => {
+		context.globalState.update("accessToken", undefined);
+		vscode.window.showInformationMessage("You have been signed out.");
+		vscode.commands.executeCommand("setContext", "keploy.signedIn", false);
+		vscode.commands.executeCommand("setContext", "keploy.signedOut", true);
+	});
 
-        context.subscriptions.push(signInCommand);
-    }
+	context.subscriptions.push(signout);
 
+	let viewKeployVersionDisposable = vscode.commands.registerCommand(
+		"keploy.KeployVersion",
+		async () => {
+			const currentVersion = await getCurrentKeployVersion();
+			vscode.window.showInformationMessage(
+				`The current version of Keploy is ${currentVersion}`
+			);
+		}
+	);
+	context.subscriptions.push(viewKeployVersionDisposable);
 
-    let signout = vscode.commands.registerCommand('keploy.SignOut', async () => {
-        context.globalState.update('accessToken', undefined);
-        vscode.window.showInformationMessage('You have been signed out.');
-        vscode.commands.executeCommand('setContext', 'keploy.signedIn', false);
-        vscode.commands.executeCommand('setContext', 'keploy.signedOut', true);
-    });
+	let viewChangeLogDisposable = vscode.commands.registerCommand(
+		"keploy.viewChangeLog",
+		() => {
+			const changeLogUrl =
+				"https://marketplace.visualstudio.com/items?itemName=Keploy.keployio";
+			vscode.env.openExternal(vscode.Uri.parse(changeLogUrl));
+		}
+	);
+	context.subscriptions.push(viewChangeLogDisposable);
 
-    context.subscriptions.push(signout);
+	let viewDocumentationDisposable = vscode.commands.registerCommand(
+		"keploy.viewDocumentation",
+		() => {
+			const docsUrl = "https://keploy.io/docs/";
+			vscode.env.openExternal(vscode.Uri.parse(docsUrl));
+		}
+	);
+	context.subscriptions.push(viewDocumentationDisposable);
 
-    let viewKeployVersionDisposable = vscode.commands.registerCommand('keploy.KeployVersion', async () => {
-        const currentVersion = await getCurrentKeployVersion();
-        vscode.window.showInformationMessage(`The current version of Keploy is ${currentVersion}`);
-    }
-    );
-    context.subscriptions.push(viewKeployVersionDisposable);
+	let getLatestVersion = vscode.commands.registerCommand(
+		"keploy.getLatestVersion",
+		async () => {
+			const latestVersion = await getKeployVersion();
+			vscode.window.showInformationMessage(
+				`The latest version of Keploy is ${latestVersion}`
+			);
+		}
+	);
+	context.subscriptions.push(getLatestVersion);
 
-    let viewChangeLogDisposable = vscode.commands.registerCommand('keploy.viewChangeLog', () => {
-        const changeLogUrl = 'https://marketplace.visualstudio.com/items?itemName=Keploy.keployio';
-        vscode.env.openExternal(vscode.Uri.parse(changeLogUrl));
-    }
-    );
-    context.subscriptions.push(viewChangeLogDisposable);
+	let updateKeployDisposable = vscode.commands.registerCommand(
+		"keploy.updateKeploy",
+		() => {
+			const options = [
+				{ label: "Keploy Docker", description: "Update using Keploy Docker" },
+				{ label: "Keploy Binary", description: "Update using Keploy Binary" },
+			];
 
-    let viewDocumentationDisposable = vscode.commands.registerCommand('keploy.viewDocumentation', () => {
-        const docsUrl = 'https://keploy.io/docs/';
-        vscode.env.openExternal(vscode.Uri.parse(docsUrl));
-    }
-    );
-    context.subscriptions.push(viewDocumentationDisposable);
+			vscode.window
+				.showQuickPick(options, {
+					placeHolder: "Choose how to update Keploy",
+				})
+				.then(async (selection) => {
+					if (selection) {
+						if (selection.label === "Keploy Docker") {
+							try {
+								await downloadAndUpdateDocker();
+								vscode.window.showInformationMessage("Keploy Docker updated!");
+							} catch (error) {
+								vscode.window.showErrorMessage(
+									`Failed to update Keploy Docker: ${error}`
+								);
+							}
+						} else if (selection.label === "Keploy Binary") {
+							try {
+								await downloadAndUpdate();
+							} catch (error) {
+								vscode.window.showErrorMessage(
+									`Failed to update Keploy binary: ${error}`
+								);
+							}
+						}
+					}
+				});
+		}
+	);
 
+	context.subscriptions.push(updateKeployDisposable);
 
-    let getLatestVersion = vscode.commands.registerCommand('keploy.getLatestVersion', async () => {
-        const latestVersion = await getKeployVersion();
-        vscode.window.showInformationMessage(`The latest version of Keploy is ${latestVersion}`);
-    }
-    );
-    context.subscriptions.push(getLatestVersion);
+	let disposable = vscode.commands.registerCommand(
+		"keploy.utg",
+		async (uri: vscode.Uri) => {
+			vscode.window.showInformationMessage("Welcome to Keploy!");
+			await Utg(context);
+		}
+	);
 
-    let updateKeployDisposable = vscode.commands.registerCommand('keploy.updateKeploy', () => {
-        //open popup to ask user to choose beteween keploy docker or keploy binary
-        const options = [
-            { label: "Keploy Docker", description: "Update using Keploy Docker" },
-            { label: "Keploy Binary", description: "Update using Keploy Binary" }
-        ];
-
-        vscode.window.showQuickPick(options, {
-            placeHolder: "Choose how to update Keploy"
-        }).then(async selection => {
-            if (selection) {
-                // Handle the user's choice here
-                if (selection.label === "Keploy Docker") {
-                    try {
-                        await downloadAndUpdateDocker();
-                        vscode.window.showInformationMessage('Keploy Docker updated!');
-                    } catch (error) {
-                        vscode.window.showErrorMessage(`Failed to update Keploy Docker: ${error}`);
-                    }
-                } else if (selection.label === "Keploy Binary") {
-                    try {
-                        await downloadAndUpdate();
-                        // this._view?.webview.postMessage({ type: 'success', value: 'Keploy binary updated!' });
-                    } catch (error) {
-                        vscode.window.showErrorMessage(`Failed to update Keploy binary: ${error}`);
-                    }
-                }
-            }
-        });
-
-    });
-
-    context.subscriptions.push(updateKeployDisposable);
-
-    // Register the command
-    let disposable = vscode.commands.registerCommand('keploy.utg', async (uri: vscode.Uri) => {
-
-        // Display a message box to the user
-        vscode.window.showInformationMessage('Welcome to Keploy!');
-
-        await Utg(context);
-    });
-
-    context.subscriptions.push(disposable);
-
+	context.subscriptions.push(disposable);
 }
 
-
-
-export function deactivate() { }
+export function deactivate() {}


### PR DESCRIPTION
# Feature Request: Go Support in VSCode Extension

## 👀 Is there an existing feature request for this?
No existing feature request found after searching the existing issues.

## 🔖 Enhancement description
Add support for Go in the Keploy VSCode extension.

## 🎤 Why should this be worked on?
- Enables generation of unit tests for Go applications
- Expands Keploy's utility to Go developers
- Aligns with Keploy's goal of simplifying testing across multiple languages

## Repository
keploy/vscode-extension

fixes: #29 

No changes in frontend