### PR TITLE
fix: update keploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: npm install
 
-      - run: xvfb-run -a npm test
+      - run: xvfb-run -a npm run coverage
         if: runner.os == 'Linux'
 
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
       - run: xvfb-run -a npm run coverage
         if: runner.os == 'Linux'
 
-      - run: npm test
+      - run: npm run coverage
         if: runner.os != 'Linux'

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "coverage": "c8 --check-coverage npm run test"
+    "coverage": "c8 --check-coverage=false npm run test"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/src/test/suites/updateKeploy.test.ts
+++ b/src/test/suites/updateKeploy.test.ts
@@ -10,6 +10,7 @@ suite("updateKeploy Test", function () {
     let createTerminalStub: sinon.SinonStub;
     let showInformationMessageStub: sinon.SinonStub;
     let onDidCloseTerminalStub: sinon.SinonStub;
+    let execStub: sinon.SinonStub;
     let terminalMock: any;
 
     setup(() => {
@@ -21,59 +22,25 @@ suite("updateKeploy Test", function () {
         createTerminalStub = sinon.stub(vscode.window, 'createTerminal').returns(terminalMock);
         showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage');
         onDidCloseTerminalStub = sinon.stub(vscode.window, 'onDidCloseTerminal');
+        execStub = sinon.stub(require("child_process"), 'exec').yields(undefined, '', '');
     });
 
     teardown(() => {
         createTerminalStub.restore();
         showInformationMessageStub.restore();
         onDidCloseTerminalStub.restore();
+        execStub.restore();
     });
 
-    test('should create a terminal and run the curl command on non-Windows platform', async () => {
+    test('downloading and updating binary should execute correct command with exec', async () => {
         sinon.stub(process, 'platform').value('linux');
 
-        let terminalCloseListener: Function | undefined;
-        onDidCloseTerminalStub.callsFake((listener) => {
-            terminalCloseListener = listener;
-            return { dispose: sinon.spy() };
-        });
+        const curlCmd = `curl --silent -L https://keploy.io/install.sh -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -noRoot`;
 
         const promise = updateKeploy.downloadAndInstallKeployBinary();
 
-        assert.strictEqual(createTerminalStub.calledOnce, true);
-        assert.strictEqual(createTerminalStub.firstCall.args[0].shellPath, '/bin/bash');
-        assert.strictEqual(terminalMock.sendText.calledOnceWith(" curl --silent -O -L https://keploy.io/install.sh && source install.sh;exit 0"), true);
-        assert.strictEqual(terminalMock.show.calledOnce, true);
-        assert.strictEqual(showInformationMessageStub.calledOnceWith('Downloading and updating Keploy binary...'), true);
+        assert.strictEqual(execStub.calledOnceWith(curlCmd), true);
 
-        if (terminalCloseListener) {
-            terminalCloseListener(terminalMock);
-        }
-
-        await promise;
-    });
-
-    test('should create a terminal with WSL on Windows platform', async () => {
-        sinon.stub(process, 'platform').value('win32');
-
-        let terminalCloseListener: Function | undefined;
-        onDidCloseTerminalStub.callsFake((listener) => {
-            terminalCloseListener = listener;
-            return { dispose: sinon.spy() };
-        });
-
-        const promise = updateKeploy.downloadAndInstallKeployBinary();
-
-        assert.strictEqual(createTerminalStub.calledOnce, true);
-        assert.strictEqual(createTerminalStub.firstCall.args[0].shellPath, 'wsl.exe');
-        assert.strictEqual(createTerminalStub.firstCall.args[0].name, 'Keploy Terminal');
-        assert.strictEqual(terminalMock.sendText.calledOnceWith(" curl --silent -O -L https://keploy.io/install.sh && source install.sh;exit 0"), true);
-        assert.strictEqual(terminalMock.show.calledOnce, true);
-        assert.strictEqual(showInformationMessageStub.calledOnceWith('Downloading and updating Keploy binary...'), true);
-
-        if (terminalCloseListener) {
-            terminalCloseListener(terminalMock);
-        }
         await promise;
     });
 


### PR DESCRIPTION
This pr fixes the way vscode-extension updates keploy

fixes: [#2316](https://github.com/keploy/keploy/issues/2316)

Recording 

![peek_5](https://github.com/user-attachments/assets/c108720a-186f-4fd0-8558-e35589642545)


