### PR TITLE
fix: remove dummy tests from the tests generated

### DIFF
--- a/scripts/utg.sh
+++ b/scripts/utg.sh
@@ -84,3 +84,12 @@ fi
 # Run the keploy command
 # echo "Running: $keployCommand"
 eval $keployCommand
+
+# Remove the dummy test
+if [ "$extension" = "py" ]; then
+  sed -i '/def test_dummy():/,+1d' "$testFilePath"
+fi
+
+if [ "$extension" = "js" ] || [ "$extension" = "ts" ]; then
+  sed -i '/describe('\''Dummy test'\'', () => {/,+4d' "$testFilePath"
+fi


### PR DESCRIPTION
Remove the dummy test's which are created when a new test file is being created by vscode-extension in case of js and python